### PR TITLE
FilteredForumSearch plugin: search backend rewrite and minor improvments

### DIFF
--- a/plugins/FilteredForumSearch/LICENSE
+++ b/plugins/FilteredForumSearch/LICENSE
@@ -1,4 +1,5 @@
-Copyright 2014 Franco Solerio <franco@solerio.net>.
+Copyright 2019 Noah Beard and Godot Community Forums Team
+(Original plugin (CategorySearch): Copyright 2014 Franco Solerio <franco@solerio.net>)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/plugins/FilteredForumSearch/class.filteredforumsearch.plugin.php
+++ b/plugins/FilteredForumSearch/class.filteredforumsearch.plugin.php
@@ -22,7 +22,7 @@
 $PluginInfo['FilteredForumSearch'] = array(
     'Name' => 'Filtered Forum Search',
     'Description' => 'Adds additional filters to search with.',
-    'Version' => '2.1.0',
+    'Version' => '2.2.0',
     'RequiredApplications' => array('Vanilla' => '2.4'),
     'RequiredTheme' => FALSE,
     'RequiredPlugins' => array ('QnA' => '1.4'),

--- a/plugins/FilteredForumSearch/class.filteredforumsearch.plugin.php
+++ b/plugins/FilteredForumSearch/class.filteredforumsearch.plugin.php
@@ -63,6 +63,7 @@ class FilteredForumSearchPlugin extends Gdn_Plugin {
 		$AdvanceParams["ADV_Filter_QNA"] = $Sender->Form->GetFormValue('ADV_Filter_QNA');
 		$AdvanceParams["ADV_Filter_CommentCount"] = $Sender->Form->GetFormValue('ADV_Filter_CommentCount');
 		$AdvanceParams["ADV_Filter_Username"] = $Sender->Form->GetFormValue('ADV_Filter_Username');
+		$AdvanceParams["ADV_Filter_SearchOccurance"] = $Sender->Form->GetFormValue('ADV_Filter_SearchOccurance');
 
         if ($Mode)
             $Sender->SearchModel->ForceSearchMode = $Mode;
@@ -123,8 +124,10 @@ class FilteredForumSearchPlugin extends Gdn_Plugin {
 
 
     // Intercept render_before to render custom view instead of original forum/search?xx page
-    public function SearchController_Render_Before($Sender) {
-        
+    public function SearchController_Render_Before($Sender)
+	{
+		Gdn_Theme::section('SearchResults');
+		
         //$Sender->AddCssFile($this->GetResource('views/style.css', FALSE, FALSE));
 		$Sender->AddCssFile('style.css', 'plugins/FilteredForumSearch');
 

--- a/plugins/FilteredForumSearch/class.filteredforumsearch.plugin.php
+++ b/plugins/FilteredForumSearch/class.filteredforumsearch.plugin.php
@@ -63,7 +63,7 @@ class FilteredForumSearchPlugin extends Gdn_Plugin {
 		$AdvanceParams["ADV_Filter_QNA"] = $Sender->Form->GetFormValue('ADV_Filter_QNA');
 		$AdvanceParams["ADV_Filter_CommentCount"] = $Sender->Form->GetFormValue('ADV_Filter_CommentCount');
 		$AdvanceParams["ADV_Filter_Username"] = $Sender->Form->GetFormValue('ADV_Filter_Username');
-		$AdvanceParams["ADV_Filter_SearchOccurance"] = $Sender->Form->GetFormValue('ADV_Filter_SearchOccurance');
+		$AdvanceParams["ADV_Filter_SearchOccurrence"] = $Sender->Form->GetFormValue('ADV_Filter_SearchOccurrence');
 
         if ($Mode)
             $Sender->SearchModel->ForceSearchMode = $Mode;

--- a/plugins/FilteredForumSearch/class.searchmodel.php
+++ b/plugins/FilteredForumSearch/class.searchmodel.php
@@ -191,13 +191,13 @@ class SearchModel extends Gdn_Model
 		}
 		
 		
-		// ADV_Filter: SearchOccurance
+		// ADV_Filter: SearchOccurrence
 		// TwistedTwigleg note:
 		//				Not perfect, but it does do a better job of returning any results that contain the keywords
 		//				instead of results that ONLY contain the keyword.
-		if (array_key_exists("ADV_Filter_SearchOccurance", $AdvanceParams) == true)
+		if (array_key_exists("ADV_Filter_SearchOccurrence", $AdvanceParams) == true)
 		{
-			$Filter_SearchOccurance = $AdvanceParams["ADV_Filter_SearchOccurance"];
+			$Filter_SearchOccurance = $AdvanceParams["ADV_Filter_SearchOccurrence"];
 			if (!empty($Filter_SearchOccurance))
 			{
 				// Only search for the exact search term:
@@ -205,64 +205,64 @@ class SearchModel extends Gdn_Model
 				{
 					if ($SQL_Query_Search_Mode == "MATCH")
 					{
-						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurance_Format_MATCH($SQL_Query_Search_Text, true);
+						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_MATCH($SQL_Query_Search_Text, true);
 					}
 					else if ($SQL_Query_Search_Mode == "LIKE")
 					{
-						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurance_Format_LIKE($SQL_Query_Search_Text, true);
+						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_LIKE($SQL_Query_Search_Text, true);
 					}
 				}
-				// Search for any occurance of the inputted search term(s):
-				else if ($Filter_SearchOccurance == "any_occurance")
+				// Search for any occurrence of the inputted search term(s):
+				else if ($Filter_SearchOccurance == "any_occurrence")
 				{
 					if ($SQL_Query_Search_Mode == "MATCH")
 					{
-						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurance_Format_MATCH($SQL_Query_Search_Text, false);
+						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_MATCH($SQL_Query_Search_Text, false);
 					}
 					else if ($SQL_Query_Search_Mode == "LIKE")
 					{
-						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurance_Format_LIKE($SQL_Query_Search_Text, false);
+						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_LIKE($SQL_Query_Search_Text, false);
 					}
 				}
-				// Use whatever the default is for searching, if an unknown SearchOccurance filter is passed.
-				// (as of when this was written, it is the same as 'any occurance')
+				// Use whatever the default is for searching, if an unknown SearchOccurrence filter is passed.
+				// (as of when this was written, it is the same as 'any occurrence')
 				else
 				{
 					if ($SQL_Query_Search_Mode == "MATCH")
 					{
-						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurance_Format_MATCH($SQL_Query_Search_Text);
+						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_MATCH($SQL_Query_Search_Text);
 					}
 					else if ($SQL_Query_Search_Mode == "LIKE")
 					{
-						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurance_Format_LIKE($SQL_Query_Search_Text);
+						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_LIKE($SQL_Query_Search_Text);
 					}
 				}
 			}
-			// If the SearchOccurance filter is empty, then use whatever the default for the format function.
-			// (as of when this was written, it is the same as 'any occurance')
+			// If the SearchOccurrence filter is empty, then use whatever the default for the format function.
+			// (as of when this was written, it is the same as 'any occurrence')
 			else
 			{
 				if ($SQL_Query_Search_Mode == "MATCH")
 				{
-					$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurance_Format_MATCH($SQL_Query_Search_Text);
+					$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_MATCH($SQL_Query_Search_Text);
 				}
 				else if ($SQL_Query_Search_Mode == "LIKE")
 				{
-					$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurance_Format_LIKE($SQL_Query_Search_Text);
+					$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_LIKE($SQL_Query_Search_Text);
 				}
 			}
 		}
-		// If there is no SearchOccurance filter in the array, then use whatever the default for the format function.
-		// (as of when this was written, it is the same as 'any occurance')
+		// If there is no SearchOccurrence filter in the array, then use whatever the default for the format function.
+		// (as of when this was written, it is the same as 'any occurrence')
 		else
 		{
 			if ($SQL_Query_Search_Mode == "MATCH")
 			{
-				$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurance_Format_MATCH($SQL_Query_Search_Text);
+				$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_MATCH($SQL_Query_Search_Text);
 			}
 			else if ($SQL_Query_Search_Mode == "LIKE")
 			{
-				$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurance_Format_LIKE($SQL_Query_Search_Text);
+				$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_LIKE($SQL_Query_Search_Text);
 			}
 		}
 		
@@ -395,7 +395,7 @@ class SearchModel extends Gdn_Model
 	
 	// Both of the functions below are helper functions for the SearchOccurance filter!
 	// Edits the search so it is formatted and ready to be used in a SQL LIKE query.
-	public function SQL_Filter_SearchOccurance_Format_LIKE($Search_Text, $Format_Search_For_Exact=false)
+	public function SQL_Filter_SearchOccurrence_Format_LIKE($Search_Text, $Format_Search_For_Exact=false)
 	{
 		if ($Format_Search_For_Exact == false)
 		{
@@ -417,7 +417,7 @@ class SearchModel extends Gdn_Model
 		return $Search_Text;
 	}
 	// Edits the search so it is formatted and ready to be used in a SQL MATCH AGAINST query.
-	public function SQL_Filter_SearchOccurance_Format_MATCH($Search_Text, $Format_Search_For_Exact=false)
+	public function SQL_Filter_SearchOccurrence_Format_MATCH($Search_Text, $Format_Search_For_Exact=false)
 	{	
 		if ($Format_Search_For_Exact == false)
 		{

--- a/plugins/FilteredForumSearch/class.searchmodel.php
+++ b/plugins/FilteredForumSearch/class.searchmodel.php
@@ -93,18 +93,12 @@ class SearchModel extends Gdn_Model
 		// *************************************
 		// Variables for storing which type of SQL query will be made based on the inputted text, and a variable to hold
 		// the search text so it can be modified without modifying the passed in $search variable.
+		
+		// These variables allow for expanding the SQL search queries in the future. This was added for
+		// "MATCH ... AGAINST ..." SQL queries, but the results were not ideal. Maybe in the future an alternative
+		// to "LIKE" will be added.
 		$SQL_Query_Search_Mode = "LIKE";
 		$SQL_Query_Search_Text = $Search;
-		// Determine which mode the search will use based on the length of the inputted search text
-		if (strlen($SQL_Query_Search_Text) > 4)
-		{
-			$SQL_Query_Search_Mode = "MATCH";
-		}
-		else
-		{
-			$SQL_Query_Search_Mode = "LIKE";
-		}
-		
 		
 		// Add filters here!
 		// *************************************
@@ -203,11 +197,7 @@ class SearchModel extends Gdn_Model
 				// Only search for the exact search term:
 				if ($Filter_SearchOccurance == "exact_only")
 				{
-					if ($SQL_Query_Search_Mode == "MATCH")
-					{
-						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_MATCH($SQL_Query_Search_Text, true);
-					}
-					else if ($SQL_Query_Search_Mode == "LIKE")
+					if ($SQL_Query_Search_Mode == "LIKE")
 					{
 						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_LIKE($SQL_Query_Search_Text, true);
 					}
@@ -215,11 +205,7 @@ class SearchModel extends Gdn_Model
 				// Search for any occurrence of the inputted search term(s):
 				else if ($Filter_SearchOccurance == "any_occurrence")
 				{
-					if ($SQL_Query_Search_Mode == "MATCH")
-					{
-						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_MATCH($SQL_Query_Search_Text, false);
-					}
-					else if ($SQL_Query_Search_Mode == "LIKE")
+					if ($SQL_Query_Search_Mode == "LIKE")
 					{
 						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_LIKE($SQL_Query_Search_Text, false);
 					}
@@ -228,11 +214,7 @@ class SearchModel extends Gdn_Model
 				// (as of when this was written, it is the same as 'any occurrence')
 				else
 				{
-					if ($SQL_Query_Search_Mode == "MATCH")
-					{
-						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_MATCH($SQL_Query_Search_Text);
-					}
-					else if ($SQL_Query_Search_Mode == "LIKE")
+					if ($SQL_Query_Search_Mode == "LIKE")
 					{
 						$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_LIKE($SQL_Query_Search_Text);
 					}
@@ -242,11 +224,7 @@ class SearchModel extends Gdn_Model
 			// (as of when this was written, it is the same as 'any occurrence')
 			else
 			{
-				if ($SQL_Query_Search_Mode == "MATCH")
-				{
-					$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_MATCH($SQL_Query_Search_Text);
-				}
-				else if ($SQL_Query_Search_Mode == "LIKE")
+				if ($SQL_Query_Search_Mode == "LIKE")
 				{
 					$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_LIKE($SQL_Query_Search_Text);
 				}
@@ -256,11 +234,7 @@ class SearchModel extends Gdn_Model
 		// (as of when this was written, it is the same as 'any occurrence')
 		else
 		{
-			if ($SQL_Query_Search_Mode == "MATCH")
-			{
-				$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_MATCH($SQL_Query_Search_Text);
-			}
-			else if ($SQL_Query_Search_Mode == "LIKE")
+			if ($SQL_Query_Search_Mode == "LIKE")
 			{
 				$SQL_Query_Search_Text = $this->SQL_Filter_SearchOccurrence_Format_LIKE($SQL_Query_Search_Text);
 			}
@@ -281,11 +255,7 @@ class SearchModel extends Gdn_Model
 				// Search only by discussion text
 				if ($Filter_SearchIn == "only_text")
 				{
-					if ($SQL_Query_Search_Mode == "MATCH")
-					{
-						$SQL_Query->where("MATCH(gdn_comment.Body) AGAINST('{$SQL_Query_Search_Text}' IN BOOLEAN MODE)", null, false, false);
-					}
-					else if ($SQL_Query_Search_Mode == "LIKE")
+					if ($SQL_Query_Search_Mode == "LIKE")
 					{
 						$SQL_Query->like('gdn_comment.Body', $SQL_Query_Search_Text);
 					}
@@ -293,11 +263,7 @@ class SearchModel extends Gdn_Model
 				// Search only by discussion title
 				else if ($Filter_SearchIn == "only_title")
 				{
-					if ($SQL_Query_Search_Mode == "MATCH")
-					{
-						$SQL_Query->where("MATCH(gdn_discussion.Name) AGAINST('{$SQL_Query_Search_Text}' IN BOOLEAN MODE)", null, false, false);
-					}
-					else if ($SQL_Query_Search_Mode == "LIKE")
+					if ($SQL_Query_Search_Mode == "LIKE")
 					{
 						$SQL_Query->like('gdn_discussion.Name', $SQL_Query_Search_Text);
 					}
@@ -305,11 +271,7 @@ class SearchModel extends Gdn_Model
 				// If for some reason the SearchIn filter passed is an unknown value, search in both the discussion title and text.
 				else
 				{
-					if ($SQL_Query_Search_Mode == "MATCH")
-					{
-						$SQL_Query->where("MATCH(gdn_discussion.Name, gdn_comment.Body) AGAINST('{$SQL_Query_Search_Text}' IN BOOLEAN MODE)", null, false, false);
-					}
-					else if ($SQL_Query_Search_Mode == "LIKE")
+					if ($SQL_Query_Search_Mode == "LIKE")
 					{
 						$SQL_Query->beginWhereGroup();
 						$SQL_Query->like('gdn_comment.Body', $SQL_Query_Search_Text);
@@ -321,11 +283,7 @@ class SearchModel extends Gdn_Model
 			// If the SearchIn filter passed is empty, search in both the discussion title and text.
 			else
 			{
-				if ($SQL_Query_Search_Mode == "MATCH")
-				{
-					$SQL_Query->where("MATCH(gdn_discussion.Name, gdn_comment.Body) AGAINST('{$SQL_Query_Search_Text}' IN BOOLEAN MODE)", null, false, false);
-				}
-				else if ($SQL_Query_Search_Mode == "LIKE")
+				if ($SQL_Query_Search_Mode == "LIKE")
 				{
 					$SQL_Query->beginWhereGroup();
 					$SQL_Query->like('gdn_comment.Body', $SQL_Query_Search_Text);
@@ -337,11 +295,7 @@ class SearchModel extends Gdn_Model
 		// If the SearchIn filter is not within the array, search in both the discussion title and text.
 		else
 		{
-			if ($SQL_Query_Search_Mode == "MATCH")
-			{
-				$SQL_Query->where("MATCH(gdn_discussion.Name, gdn_comment.Body) AGAINST('{$SQL_Query_Search_Text}' IN BOOLEAN MODE)", null, false, false);
-			}
-			else if ($SQL_Query_Search_Mode == "LIKE")
+			if ($SQL_Query_Search_Mode == "LIKE")
 			{
 				$SQL_Query->beginWhereGroup();
 				$SQL_Query->like('gdn_comment.Body', $SQL_Query_Search_Text);
@@ -393,13 +347,13 @@ class SearchModel extends Gdn_Model
 	
 	
 	
-	// Both of the functions below are helper functions for the SearchOccurance filter!
 	// Edits the search so it is formatted and ready to be used in a SQL LIKE query.
+	// Allows for multiple search terms, breaks terms up using spaces (" ")
 	public function SQL_Filter_SearchOccurrence_Format_LIKE($Search_Text, $Format_Search_For_Exact=false)
 	{
 		if ($Format_Search_For_Exact == false)
 		{
-			// Search for all occurances of the word(s) inputted (akin to Google search)
+			// Search for all occurrences of the word(s) inputted (akin to Google search)
 			// We can do this by splitting the terms by space, adding at the beginning and end of each term.
 			// It is not perfect, but it's better than nothing.
 			$Search_Terms = explode(' ', $Search_Text);
@@ -412,27 +366,6 @@ class SearchModel extends Gdn_Model
 		else
 		{
 			// Do nothing!
-		}
-		
-		return $Search_Text;
-	}
-	// Edits the search so it is formatted and ready to be used in a SQL MATCH AGAINST query.
-	public function SQL_Filter_SearchOccurrence_Format_MATCH($Search_Text, $Format_Search_For_Exact=false)
-	{	
-		if ($Format_Search_For_Exact == false)
-		{
-			// Search for all occurances of the word(s) inputted (akin to Google search)
-			// We can do this by splitting the terms by space, adding ',' between each term.
-			$Search_Terms = explode(' ', $Search_Text);
-			$Search_Text = '';
-			foreach ($Search_Terms as $Key => $Value)
-			{
-				$Search_Text = $Search_Text.$Value.',';
-			}
-		}
-		else
-		{
-			$Search_Text = '"'.$Search_Text.'"';
 		}
 		
 		return $Search_Text;

--- a/plugins/FilteredForumSearch/views/index.php
+++ b/plugins/FilteredForumSearch/views/index.php
@@ -11,6 +11,7 @@
 	$ADV_Filter_SearchedCategory=$Form->GetFormValue('ADV_Filter_Category');
 	$ADV_Filter_SearchedQNA=$Form->GetFormValue('ADV_Filter_QNA');
 	$ADV_Filter_SearchedCommentCount=$Form->GetFormValue('ADV_Filter_CommentCount');
+	$ADV_Filter_SearchedExact=$Form->GetFormValue('ADV_Filter_SearchOccurance');
 
 
 	// Variables for discussion/title searching
@@ -22,23 +23,29 @@
 
 	// Variables for answered dropdown
 	$AnswerDropdownOptions = array(
-				'' => Gdn::translate('All Discussions and Questions'),
-				'Answered' => Gdn::translate('Only Answered Questions'),
-				'Accepted' => Gdn::translate('Only Accepted Questions'),
-				'Unanswered' => Gdn::translate('Only Unanswered Questions'),
-				'No_QA' => Gdn::translate('Only Discussions (No Questions)'),
-				'Only_QA' => Gdn::translate('Only Questions (No Discussions)'));
+				'' => Gdn::translate('All discussions and questions'),
+				'Answered' => Gdn::translate('Only answered questions'),
+				'Accepted' => Gdn::translate('Only accepted questions'),
+				'Unanswered' => Gdn::translate('Only unanswered questions'),
+				'No_QA' => Gdn::translate('Only discussions (no questions)'),
+				'Only_QA' => Gdn::translate('Only questions (no discussions)'));
 	$AnswerDropdownFields = array('TextField' => 'Text', 'ValueField' => 'Code', 'Value' => $ADV_Filter_SearchedQNA);
 
 	// Variables for post count dropdown
 	$CommentCountDropdownOptions = array(
 				'' => 'All Discussions',
-				'over_zero' => Gdn::translate('Only Over 0 comments/replies'),
-				'over_one' => Gdn::translate('Only Over 1 comments/replies'),
-				'over_two' => Gdn::translate('Only Over 2 comments/replies'),
-				'over_five' => Gdn::translate('Only Over 5 comments/replies'),
-				'over_ten' => Gdn::translate('Only Over 10 comments/replies'));
+				'over_zero' => Gdn::translate('Only over 0 comments/replies'),
+				'over_one' => Gdn::translate('Only over 1 comments/replies'),
+				'over_two' => Gdn::translate('Only over 2 comments/replies'),
+				'over_five' => Gdn::translate('Only over 5 comments/replies'),
+				'over_ten' => Gdn::translate('Only over 10 comments/replies'));
 	$CommentCountDropdownFields = array('TextField' => 'Text', 'ValueField' => 'Code', 'Value' => $ADV_Filter_SearchedCommentCount);
+	
+	// Variables for occurance dropdown searching
+	$SearchOccuranceDropdownOptions = array(
+				'any_occurance' => 'Return all occurances',
+				'exact_only' => Gdn::translate('Return only exact occurances'));
+	$SearchOccuranceDropdownFields = array('TextField' => 'Text', 'ValueField' => 'Code', 'Value' => $ADV_Filter_SearchedExact);
 
 
 	echo  
@@ -46,8 +53,7 @@
 		
 		// Search input
 		'<div class="SiteSearch">',
-		$Form->Label('Search Text', 'Search'),
-		$Form->TextBox('Search'),
+		$Form->TextBox('Search', array('placeholder' => Gdn::translate("Search"))),
 		$Form->Button('Search', array('Name' => '')),
 		'</div>',
 		
@@ -88,7 +94,13 @@
 		// Username input
 		'<div class="SearchUsername">',
 		$Form->Label('Filter by Username (case sensitive)', 'ADV_Filter_Username'), ' ',
-		$Form->TextBox('ADV_Filter_Username'),
+		$Form->TextBox('ADV_Filter_Username', array('placeholder' => Gdn::translate("Username"))),
+		'</div>',
+		
+		// Search occurance dropdown
+		'<div class="SearchOccuranceDropdown">',
+		$Form->Label('Filter by occurance', 'ADV_Filter_SearchOccurance'), ' ',
+		$Form->DropDown('ADV_Filter_SearchOccurance', $SearchOccuranceDropdownOptions, $SearchOccuranceDropdownFields).
 		'</div>',
 		
 		'<div class="SearchNote">',

--- a/plugins/FilteredForumSearch/views/index.php
+++ b/plugins/FilteredForumSearch/views/index.php
@@ -11,7 +11,7 @@
 	$ADV_Filter_SearchedCategory=$Form->GetFormValue('ADV_Filter_Category');
 	$ADV_Filter_SearchedQNA=$Form->GetFormValue('ADV_Filter_QNA');
 	$ADV_Filter_SearchedCommentCount=$Form->GetFormValue('ADV_Filter_CommentCount');
-	$ADV_Filter_SearchedExact=$Form->GetFormValue('ADV_Filter_SearchOccurance');
+	$ADV_Filter_SearchedOccurrence=$Form->GetFormValue('ADV_Filter_SearchOccurrence');
 
 
 	// Variables for discussion/title searching
@@ -42,10 +42,10 @@
 	$CommentCountDropdownFields = array('TextField' => 'Text', 'ValueField' => 'Code', 'Value' => $ADV_Filter_SearchedCommentCount);
 	
 	// Variables for occurance dropdown searching
-	$SearchOccuranceDropdownOptions = array(
-				'any_occurance' => 'Return all occurances',
-				'exact_only' => Gdn::translate('Return only exact occurances'));
-	$SearchOccuranceDropdownFields = array('TextField' => 'Text', 'ValueField' => 'Code', 'Value' => $ADV_Filter_SearchedExact);
+	$SearchOccurrenceDropdownOptions = array(
+				'any_occurrence' => 'Return all occurrences',
+				'exact_only' => Gdn::translate('Return only exact occurrences'));
+	$SearchOccurrenceDropdownFields = array('TextField' => 'Text', 'ValueField' => 'Code', 'Value' => $ADV_Filter_SearchedOccurrence);
 
 
 	echo  
@@ -98,9 +98,9 @@
 		'</div>',
 		
 		// Search occurance dropdown
-		'<div class="SearchOccuranceDropdown">',
-		$Form->Label('Filter by occurance', 'ADV_Filter_SearchOccurance'), ' ',
-		$Form->DropDown('ADV_Filter_SearchOccurance', $SearchOccuranceDropdownOptions, $SearchOccuranceDropdownFields).
+		'<div class="SearchOccurrenceDropdown">',
+		$Form->Label('Filter by occurrence', 'ADV_Filter_SearchOccurrence'), ' ',
+		$Form->DropDown('ADV_Filter_SearchOccurrence', $SearchOccurrenceDropdownOptions, $SearchOccurrenceDropdownFields).
 		'</div>',
 		
 		'<div class="SearchNote">',


### PR DESCRIPTION
I made quite a few changes to the FilterForumSearch plugin to improve searching, performance, and to make it more compatible with Vanilla. This is a fairly large pull request that might need to be broken up into multiple, smaller pull requests.

**This PR needs to be tested/reviewed due to it changing the fundamentals.**

First however, here are the non-fundamental changes:

* Added `Gdn_Theme::Section` to `class.filteredforumsearch.plugin.php`
  * Thanks to donshakespeare for the suggestion!
* Removed search label and added placeholder text to the search input field to more closely mirror Vanilla's default search page.
  * Thanks to donshakespeare for the suggestion!
* Added placeholder text for the username input field.

I'm not too worried about these changes breaking anything. I tested and everything seems to still be working fine in regard to the changes listed above. These changes will hopefully make the plugin more compatible with Vanilla, other plugins, and CSS.

______

I made some changes so the plugin searches using multiple search terms, akin to Google and other search engines. This required changing how searching works in the plugin.

Prior to this change, searching something like "Help Test" would *only* return results containing "Help Test" exactly. With this change, searching "Help Test" will return results containing "Help", "Test", and/or "Help Test". This is replications the default functionality present in other search engines.

While I think everything still works, it would probably be a good idea to do some thorough testing before merging this PR and pushing an update.

Here are the fundamental/breaking changes:

* **Search text/terms over 4 characters now use `SQL WHERE MATCH (...) AGAINST (...)` instead of `SQL WHERE LIKE (...)`**.
  * This gives improved search performance using SQL, since as far as I can tell using `MATCH` is faster than `LIKE` with SQL databases.
  * Seems to return the same results as `LIKE`.
  * Search text/terms under 4 characters use `LIKE` as a fallback, because `MATCH` only works on text over 5 characters by default.
  * This allows for more options and filters!
* New filter: filter by occurrence. This allows the user to customize how the text/terms inputted are used within the SQL search.
  * **By default, searches are broken up into multiple search terms**.
    * This means, for example, `Foo Bar` will be broken up into two search terms (`Foo`, and `Bar`). Instead of searching exactly for `Foo Bar` within the text, the search will return results containing `Foo`, `Bar`, `Bar Foo`, and `Foo Bar`.
    * This is the default for many search engines, so I set it as the default for this plugin.
  * Searches can search for exact occurrences of the inputted search terms/text.
    * This means if you search `Cat Dog` with exact occurrence matching, only results containing "Cat Dog" will be returned.
    * Searching for exact occurances will give the same functionality the FilteredForumSearch plugin currently has prior to this PR.
  * Searches can be set to search for exact or multiple terms on a per search basis through a new dropdown.
  * This functionality is possible thanks to using `SQL WHERE MATCH (...) AGAINST (...)`. Terms are broken up by spaces, with `,` added between terms.
  * For searches using 4 characters or less, `%` is added to both sides of each of the inputted search terms. This isn't a perfect solution, as it doesn't search using individual terms, but it gives decent results that are probably good enough for search text/terms under 4 characters.
  * Results are not sorted by relevance, but rather by date. This may change in the future, but as I was working on this I couldn't find a great way to filter by relevance, so for now it only filters by date.

**These changes may break things and/or not work as expected**. Because of this, I think it is best to wait awhile before merging this PR so it can be tested thoroughly. I plan to do some thorough testing soon to hopefully catch any issues that might have been introduced.

Hopefully this PR will make the plugin more useful and act more like other search engines out there. Any feedback/suggestions/other are welcome!

_____

**EDIT:**

See comment below. Looks like I will need to remove the `MATCH ... AGAINST ...` code, as it doesn't do what the plugin needs.