### PR TITLE
FilteredForumSearch: Major bug fix (and minor improvements)

### DIFF
--- a/plugins/FilteredForumSearch/class.filteredforumsearch.plugin.php
+++ b/plugins/FilteredForumSearch/class.filteredforumsearch.plugin.php
@@ -40,8 +40,7 @@ class FilteredForumSearchPlugin extends Gdn_Plugin {
     // and to call the overridden model's search() function with the added $CategoryFilter variable
     //
     public function SearchController_Index_Create($Sender, $Page = '')
-	{
-        $Sender->AddJsFile('search.js');
+	{	
         $Sender->Title(Gdn::translate('Search'));
 
         SaveToConfig('Garden.Format.EmbedSize', '160x90', FALSE);
@@ -95,21 +94,6 @@ class FilteredForumSearchPlugin extends Gdn_Plugin {
         if ($NumResults == $Offset + $Limit)
             $NumResults++;
 
-		// TwistedTwigleg note:
-		//		Not needed anymore? Will need to investigate...
-        // Build a pager
-        $PagerFactory = new Gdn_PagerFactory();
-        $Sender->Pager = $PagerFactory->GetPager('MorePager', $Sender);
-        $Sender->Pager->MoreCode = 'More Results';
-        $Sender->Pager->LessCode = 'Previous Results';
-        $Sender->Pager->ClientID = 'Pager';
-        $Sender->Pager->Configure(
-            $Offset,
-            $Limit,
-            $NumResults,
-            'dashboard/search/%1$s/%2$s/?Search='.Gdn_Format::Url($Search)
-        );
-
         $Sender->CanonicalUrl(Url('search', TRUE));
 
         $Sender->Render();
@@ -128,8 +112,10 @@ class FilteredForumSearchPlugin extends Gdn_Plugin {
 	{
 		Gdn_Theme::section('SearchResults');
 		
-        //$Sender->AddCssFile($this->GetResource('views/style.css', FALSE, FALSE));
-		$Sender->AddCssFile('style.css', 'plugins/FilteredForumSearch');
+		// TwistedTwigleg note:
+		//		If you have a CSS file called search_style.css, you may need to change the name of this CSS file
+		//		so it is loaded correctly.
+        $Sender->AddCssFile('search_style.css', 'plugins/FilteredForumSearch');
 
         $View = 'dashboard/search/index.php';
         $ThemeView = CombinePaths(array(PATH_THEMES, $Sender->Theme, strtolower($this->GetPluginFolder(false)), $View));

--- a/plugins/FilteredForumSearch/design/search_style.css
+++ b/plugins/FilteredForumSearch/design/search_style.css
@@ -1,0 +1,9 @@
+/* Copyright 2019 Noah Beard and Godot Community Forums Team */
+
+.SearchForm .Button, .search-form .Button
+{
+	position: relative;
+	left: auto;
+	right: auto;
+	width: 75%;
+}

--- a/plugins/FilteredForumSearch/design/style.css
+++ b/plugins/FilteredForumSearch/design/style.css
@@ -1,6 +1,0 @@
-/* Copyright 2014 Franco Solerio */
-
-div.SearchCategoryDropdown {
-    padding-bottom: 8px;
-    padding-top: 8px;
-}

--- a/plugins/FilteredForumSearch/views/index.php
+++ b/plugins/FilteredForumSearch/views/index.php
@@ -16,7 +16,7 @@
 
 	// Variables for discussion/title searching
 	$SearchInDropdownOptions = array(
-				'' => 'Search in discussion contents and title',
+				'' => Gdn::translate('Search in discussion contents and title'),
 				'only_text' => Gdn::translate('Search in discussion contents'),
 				'only_title' => Gdn::translate('Search in discussion title'));
 	$SearchInDropdownFields = array('TextField' => 'Text', 'ValueField' => 'Code', 'Value' => $ADV_Filter_SearchedSearchIn);
@@ -33,7 +33,7 @@
 
 	// Variables for post count dropdown
 	$CommentCountDropdownOptions = array(
-				'' => 'All Discussions',
+				'' => Gdn::translate('All Discussions'),
 				'over_zero' => Gdn::translate('Only over 0 comments/replies'),
 				'over_one' => Gdn::translate('Only over 1 comments/replies'),
 				'over_two' => Gdn::translate('Only over 2 comments/replies'),
@@ -43,7 +43,7 @@
 	
 	// Variables for occurance dropdown searching
 	$SearchOccurrenceDropdownOptions = array(
-				'any_occurrence' => 'Return all occurrences',
+				'any_occurrence' => Gdn::translate('Return all occurrences'),
 				'exact_only' => Gdn::translate('Return only exact occurrences'));
 	$SearchOccurrenceDropdownFields = array('TextField' => 'Text', 'ValueField' => 'Code', 'Value' => $ADV_Filter_SearchedOccurrence);
 
@@ -54,7 +54,6 @@
 		// Search input
 		'<div class="SiteSearch">',
 		$Form->TextBox('Search', array('placeholder' => Gdn::translate("Search"))),
-		$Form->Button('Search', array('Name' => '')),
 		'</div>',
 		
 		'<br />',
@@ -69,47 +68,46 @@
 		
 		// SearchIn dropdown
 		'<div class="SearchInDropdown">',
-		$Form->Label('Filter search location', 'ADV_Filter_SearchIn'), ' ',
+		$Form->Label(Gdn::translate('Filter search location'), 'ADV_Filter_SearchIn'), ' ',
 		$Form->DropDown('ADV_Filter_SearchIn', $SearchInDropdownOptions, $SearchInDropdownFields).
 		'</div>',
 		
 		// Category dropdown (provided by SearchCategory plugin code!)
 		'<div class="SearchCategoryDropdown">',
-		$Form->Label('Filter by Category', 'ADV_Filter_Category'), ' ',
+		$Form->Label(Gdn::translate('Filter by Category'), 'ADV_Filter_Category'), ' ',
 		$Form->CategoryDropDown('ADV_Filter_Category', array('Value' => $ADV_Filter_SearchedCategory, 'IncludeNull' => true)).
 		'</div>',
 		
 		// Q&A dropdown
 		'<div class="SearchAnswerDropdown">',
-		$Form->Label('Filter by Q&A', 'ADV_Filter_QNA'), ' ',
+		$Form->Label(Gdn::translate('Filter by Q&A'), 'ADV_Filter_QNA'), ' ',
 		$Form->DropDown('ADV_Filter_QNA', $AnswerDropdownOptions, $AnswerDropdownFields).
 		'</div>',
 		
 		// Comment count dropdown
 		'<div class="SearchCommentCountDropdown">',
-		$Form->Label('Filter by Comment Count', 'ADV_Filter_CommentCount'), ' ',
+		$Form->Label(Gdn::translate('Filter by Comment Count'), 'ADV_Filter_CommentCount'), ' ',
 		$Form->DropDown('ADV_Filter_CommentCount', $CommentCountDropdownOptions, $CommentCountDropdownFields).
 		'</div>',
 		
 		// Username input
 		'<div class="SearchUsername">',
-		$Form->Label('Filter by Username (case sensitive)', 'ADV_Filter_Username'), ' ',
+		$Form->Label(Gdn::translate('Filter by Username (case sensitive)'), 'ADV_Filter_Username'), ' ',
 		$Form->TextBox('ADV_Filter_Username', array('placeholder' => Gdn::translate("Username"))),
 		'</div>',
 		
-		// Search occurance dropdown
+		// Search occurrence dropdown
 		'<div class="SearchOccurrenceDropdown">',
-		$Form->Label('Filter by occurrence', 'ADV_Filter_SearchOccurrence'), ' ',
+		$Form->Label(Gdn::translate('Filter by occurrence'), 'ADV_Filter_SearchOccurrence'), ' ',
 		$Form->DropDown('ADV_Filter_SearchOccurrence', $SearchOccurrenceDropdownOptions, $SearchOccurrenceDropdownFields).
 		'</div>',
 		
-		'<div class="SearchNote">',
+		// Search button
 		'<br />',
-		'<center><h4>',
-		$Form->Label('Submit search to apply filter(s)', 'ADV_Search_Note'), ' ',
-		'</h4></center>',
+		'<center>',
+		'<button class="Button" type="Submit">'.Gdn::translate('Submit search with filter(s)').'</button>',
+		'</center>',
 		'<br />',
-		'</div>',
 		
 		// Close collapse div
 		'</div>',

--- a/plugins/FilteredForumSearch/views/index.php
+++ b/plugins/FilteredForumSearch/views/index.php
@@ -6,6 +6,12 @@
 	$Form = $this->Form;
 	$Form->InputPrefix = '';
 
+	
+	// WORKS
+	//var_dump(Gdn::session()->isValid());
+	
+	//var_dump(Gdn::session()->User);
+
 
 	$ADV_Filter_SearchedSearchIn=$Form->GetFormValue('ADV_Filter_SearchIn');
 	$ADV_Filter_SearchedCategory=$Form->GetFormValue('ADV_Filter_Category');
@@ -76,6 +82,14 @@
 		'<div class="SearchCategoryDropdown">',
 		$Form->Label(Gdn::translate('Filter by Category'), 'ADV_Filter_Category'), ' ',
 		$Form->CategoryDropDown('ADV_Filter_Category', array('Value' => $ADV_Filter_SearchedCategory, 'IncludeNull' => true)).
+		
+		// NOTE: only return discussion types that this user can see, instead of returning ALL of them
+		//$permissionCategory = CategoryModel::permissionCategory($this->CategoryID);
+		//$discussionTypes = CategoryModel::allowedDiscussionTypes($permissionCategory, isset($category) ? $category : []);
+		//$Form->CategoryDropDown('ADV_Filter_Category', array('Value' => $ADV_Filter_SearchedCategory, 'IncludeNull' => true, 'PermFilter'=> ['AllowedDiscussionTypes' => $discussionTypes])).
+		
+		// END OF NOTE
+		
 		'</div>',
 		
 		// Q&A dropdown


### PR DESCRIPTION
Changes:

* Added more `Gdn::translate` function calls to fix everywhere it was missing. Now it should be applied to every text element.
* Removed the footnote and replaced it with a button that will start the search, removing the need to scroll up and press enter.
* Changed the name of the CSS file so it would not be overwritten and edited the CSS to properly position the button for the Godot forums theme.

More importantly, I fixed a **huge** issue I didn't realize until recently:

* Results returned by the search will only contain discussions the user has permission to view.

Prior to this, the search would return results from every discussion, regardless of whether the user was supposed to have permission or not. Selecting the results wouldn't bring them to the topic, thankfully, however they could still see the preview text. Still, this means they got results they were not supposed to see (like topics in the Moderation board)

This commit fixes the issue by only returning results that the user has permission to see. I did some testing and it seems to be fixed now. Results returned from the search seem to only be what the user can view, fixing the issue.