### PR TITLE
Added GitHub Gist support to the Mediator plugin.

### DIFF
--- a/plugins/Mediator/README.md
+++ b/plugins/Mediator/README.md
@@ -13,5 +13,4 @@ Mediator converts embeddable resource urls to embedded resources. The current me
 - ![](https://plus.google.com/_/favicon?domain=gyazo.com) Gyazo
 - ![](https://plus.google.com/_/favicon?domain=pastebin.com) Pastebin
 - ![](https://plus.google.com/_/favicon?domain=soundcloud.com) Soundcloud
-- ![]() GyfCat
 

--- a/plugins/Mediator/class.mediator.plugin.php
+++ b/plugins/Mediator/class.mediator.plugin.php
@@ -18,8 +18,8 @@
 
 $PluginInfo['Mediator'] = array(
 	'Name' => 'Mediator',
-	'Description' => 'Allows automatic embedding of media by converting media links to embed code. Supports Youtube, Vimeo, Imgur, Pastebin, Soundcloud [Bandcamp], Gyazo.',
-	'Version' => '0.3.18',
+	'Description' => 'Allows automatic embedding of media by converting media links to embed code. Supports Youtube, Vimeo, Imgur, Pastebin, Soundcloud [Bandcamp], Gyazo, GfyCat, GitHub-gist.',
+	'Version' => '0.4.18',
 	'Date' => '01 Feb 2012',
 	'Author' => 'Seon-Wook Park (extended by the Godot forums team)',
 	'AuthorEmail' => 'twistedtwigleg@randommomentania.com',

--- a/plugins/Mediator/mediator.js
+++ b/plugins/Mediator/mediator.js
@@ -423,6 +423,7 @@
 		frame.prop('src', "data:text/html;charset=utf-8,<body><script src='" + ("https://gist.github.com" + url_id + ".js") + "'></script></body>");
 		frame.prop('style', "width: 100%; height: 100%; min-height: 150px");
 		frame.prop('allowfullscreen', "");
+		frame.prop('class', "github_gist_iframe");
 		frame[0].frameBorder = 0;
 		inner_div[0].appendChild(frame[0]);
 		

--- a/plugins/Mediator/mediator.js
+++ b/plugins/Mediator/mediator.js
@@ -133,11 +133,16 @@
 		if (urlo.host.match(/^bandcamp\.[^\.]+\.com$/i) || urlo.host.match(/^[^\.]+\.bandcamp\.com$/i)) {
 			return ReplaceBandcamp(url, elem, $elem);
 		}
-        
-        // Custom addition: GyfCat
-        if (urlo.host == 'gfycat.com' || urlo.host == 'www.gfycat.com') {
-            var url_id = urlo.path;
+		
+		// Custom addition: GyfCat
+		if (urlo.host == 'gfycat.com' || urlo.host == 'www.gfycat.com') {
+			var url_id = urlo.path;
 			return ReplaceGfyCat(url_id, elem, $elem);
+		}
+		// Custom addition: GitHub gist
+		if (urlo.host == 'gist.github.com' || urlo.host == 'www.gist.github.com') {
+			var url_id = urlo.path;
+			return ReplaceGitHubGist(url_id, elem, $elem);
 		}
         
 	}
@@ -360,19 +365,71 @@
 		});
 	}
     
-    function ReplaceGfyCat (url_id, elem, $elem) {
+	function ReplaceGfyCat (url_id, elem, $elem) {
 		var newel = $('<iframe>');
 		newel.prop('height', height);
 		newel.prop('src', 'https://gfycat.com/ifr'+ url_id + '?autoplay=0');
+
+		newel.prop('allowfullscreen', '');
+		newel.prop('frameborder', '0');
+		newel.prop('width', '100%');
+		newel.prop('scolling', 'no');
+
+		CommonSetting(newel, $elem, 'GfyCat');
+
+		$elem.replaceWith(newel);
+	}
+	
+	function ReplaceGitHubGist (url_id, elem, $elem) {
 		
-        newel.prop('allowfullscreen', '');
-        newel.prop('frameborder', '0');
-        newel.prop('width', '100%');
-        newel.prop('scolling', 'no');
-        
-        CommonSetting(newel, $elem, 'GfyCat');
+		// TwistedTwigleg note: While GitHub has a embeded that simply uses a <script> HTML tag, for some reason it does not work
+		// in Vanilla without being added to an iFrame. I wasn't able to find a way around it, with the solution below being the 
+		// best I could find... It is not ideal though. That said, after several hours of working, this was the best I could make.
 		
-        $elem.replaceWith(newel);
+		// Minimal Iframe GitHub gist example:
+		/*
+		var newel = $('<iframe>');
+		// Inspired by this GitHub gist iframe embed code
+		// https://gist.github.com/pixelitystudios/6d254e24b528838813d905f9c45fba81
+		newel.prop('src', "data:text/html;charset=utf-8,<body><script src='" + ("https://gist.github.com" + url_id + ".js") + "'></script></body>");
+		CommonSetting(newel, $elem, 'GitHubGist');
+		$elem.replaceWith(newel);
+		*/
+		
+		
+		// Make a div that can be resized based on the size of the GitHub gist.
+		var resize_div = $('<div>');
+		resize_div.prop('style', "overflow: hidden; resize: vertical; outline-width: thin; min-height: 200px; box-shadow: none");
+		
+		// Make the text (and link) that points to the GitHub gist URL.
+		var prelink_text = $('<p>');
+		prelink_text.prop('style', "margin: 0px;");
+		prelink_text[0].append("GitHub gist:");
+		// The actually link element
+		var link_text = $('<a>');
+		link_text.prop('href', ("https://gist.github.com" + url_id));
+		link_text[0].append(url_id);
+		prelink_text[0].appendChild(link_text[0])
+		resize_div[0].appendChild(prelink_text[0])
+		
+		// Used for additional padding to keep the drag margin on the bottom away from the resize button.
+		// It is not perfect though...
+		var inner_div = $('<div>');
+		inner_div.prop('style', "height: 100%; padding-bottom: 42px");
+		resize_div[0].appendChild(inner_div[0]);
+		
+		// Make the iFrame containing the GitHub gist:
+		var frame = $('<iframe>');
+		frame.prop('src', "data:text/html;charset=utf-8,<body><script src='" + ("https://gist.github.com" + url_id + ".js") + "'></script></body>");
+		frame.prop('style', "width: 100%; height: 100%; min-height: 150px");
+		frame.prop('allowfullscreen', "");
+		frame[0].frameBorder = 0;
+		inner_div[0].appendChild(frame[0]);
+		
+		// Apply the resize_div
+		CommonSetting(resize_div, $elem, 'GitHubGist');
+		$elem.replaceWith(resize_div);
+		
 	}
     
 }(jQuery));


### PR DESCRIPTION
I added GitHub Gist support through the Mediator plugin. It is not perfect, but it is better than just having the link. After several hours of working on it, adding GitHub gist support was not as easy as I initially thought it would be.

I was initially going to use something similar to the links in the issue about adding GitHub Gist embeds in [the issue on the theme repository](https://github.com/TwistedTwigleg/vanilla-bootstrap/issues/29), but I couldn't get it working when injected into the post. For some reason, using a `<script>` tag within a post didn't do anything and after lots of debugging, I wasn't able to figure out why.
So I decided to slap the embed into an iFrame, which worked but unfortunately does not resize to the content size automatically. I added a resize `<div>` element to help mitigate the issue. Unfortunately, the resize `<div>` has a strange issue where it's padding is too large initially, but when resized it snaps into the correct position.

When/If this PR is pulled in, it should close the issue on the theme repository.
@Megalomaniak, do you mind trying it out once you have a chance?