### PR TITLE
FilteredForumSearch plugin version 2.4.0

### DIFF
--- a/plugins/FilteredForumSearch/class.filteredforumsearch.plugin.php
+++ b/plugins/FilteredForumSearch/class.filteredforumsearch.plugin.php
@@ -22,10 +22,9 @@
 $PluginInfo['FilteredForumSearch'] = array(
     'Name' => 'Filtered Forum Search',
     'Description' => 'Adds additional filters to search with.',
-    'Version' => '2.3.1',
+    'Version' => '2.4.0',
     'RequiredApplications' => array('Vanilla' => '2.4'),
     'RequiredTheme' => FALSE,
-    'RequiredPlugins' => array ('QnA' => '1.4'),
     'MobileFriendly' => TRUE,
     'HasLocale' => FALSE,
     'RegisterPermissions' => FALSE,
@@ -51,10 +50,6 @@ class FilteredForumSearchPlugin extends Gdn_Plugin {
         $Search = $Sender->Form->GetFormValue('Search');
         $Mode = $Sender->Form->GetFormValue('Mode');
 		
-		// TwistedTwigleg note:
-		//		Need to look at this file! Looked at most of it and it looks good, just need to
-		//		double check a few things.
-		//
 		// Send all additional advance filter data in a single array
 		$AdvanceParams = array();
 		$AdvanceParams["ADV_Filter_SearchIn"] = $Sender->Form->GetFormValue('ADV_Filter_SearchIn');

--- a/plugins/FilteredForumSearch/class.searchmodel.php
+++ b/plugins/FilteredForumSearch/class.searchmodel.php
@@ -82,9 +82,7 @@ class SearchModel extends Gdn_Model
 		
 		// The SQL query will always need the following as the beginning, regardless of which filter(s) are applied.
         $SQL_Query = Gdn::sql();
-        
-        $SQL_Query = Gdn::sql();
-		$SQL_Query->reset();
+        $SQL_Query->reset();
         $SQL_Query->select("gdn_discussion.*");
         // Get comment data AFTER getting the discussion data so comment data overrides discussion data with the same fields (which works for this case)
 		$SQL_Query->select("gdn_comment.*");

--- a/plugins/FilteredForumSearch/design/search_style.css
+++ b/plugins/FilteredForumSearch/design/search_style.css
@@ -1,6 +1,6 @@
 /* Copyright 2019 Noah Beard and Godot Community Forums Team */
 
-.SearchForm .Button, .search-form .button
+.SearchForm .Button, .search-form .Button
 {
 	position: relative;
 	left: auto;

--- a/plugins/FilteredForumSearch/views/index.php
+++ b/plugins/FilteredForumSearch/views/index.php
@@ -6,12 +6,9 @@
 	$Form = $this->Form;
 	$Form->InputPrefix = '';
 
-	
 	// WORKS
 	//var_dump(Gdn::session()->isValid());
-	
 	//var_dump(Gdn::session()->User);
-
 
 	$ADV_Filter_SearchedSearchIn=$Form->GetFormValue('ADV_Filter_SearchIn');
 	$ADV_Filter_SearchedCategory=$Form->GetFormValue('ADV_Filter_Category');
@@ -52,7 +49,19 @@
 				'any_occurrence' => Gdn::translate('Return all occurrences'),
 				'exact_only' => Gdn::translate('Return only exact occurrences'));
 	$SearchOccurrenceDropdownFields = array('TextField' => 'Text', 'ValueField' => 'Code', 'Value' => $ADV_Filter_SearchedOccurrence);
-
+    
+    
+    // (Optional: QNA dropdown when the QNA plugin is enabled. Thanks donshakespeare from the Vanilla forums for the code snippet!)
+    $QNA_Menu = '';
+    if (class_exists('QnAPlugin'))
+    {
+        $QNA_Menu = '<div class="SearchAnswerDropdown">'.
+            $Form->Label(Gdn::translate("Fitler by Q&A"), 'ADV_Filter_QNA').
+            ' '.
+            $Form->DropDown('ADV_Filter_QNA', $AnswerDropdownOptions, $AnswerDropdownFields).
+            '</div>';
+    }
+    
 
 	echo  
 	$Form->Open(array('action' => Url('/search'), 'method' => 'get')),
@@ -83,20 +92,11 @@
 		$Form->Label(Gdn::translate('Filter by Category'), 'ADV_Filter_Category'), ' ',
 		$Form->CategoryDropDown('ADV_Filter_Category', array('Value' => $ADV_Filter_SearchedCategory, 'IncludeNull' => true)).
 		
-		// NOTE: only return discussion types that this user can see, instead of returning ALL of them
-		//$permissionCategory = CategoryModel::permissionCategory($this->CategoryID);
-		//$discussionTypes = CategoryModel::allowedDiscussionTypes($permissionCategory, isset($category) ? $category : []);
-		//$Form->CategoryDropDown('ADV_Filter_Category', array('Value' => $ADV_Filter_SearchedCategory, 'IncludeNull' => true, 'PermFilter'=> ['AllowedDiscussionTypes' => $discussionTypes])).
-		
-		// END OF NOTE
-		
 		'</div>',
 		
-		// Q&A dropdown
-		'<div class="SearchAnswerDropdown">',
-		$Form->Label(Gdn::translate('Filter by Q&A'), 'ADV_Filter_QNA'), ' ',
-		$Form->DropDown('ADV_Filter_QNA', $AnswerDropdownOptions, $AnswerDropdownFields).
-		'</div>',
+		// Q&A dropdown (if QnA plugin is enabled)
+		$QNA_Menu.
+        
 		
 		// Comment count dropdown
 		'<div class="SearchCommentCountDropdown">',


### PR DESCRIPTION
Fixed a bunch of bugs and issues in the FilteredForumSearch plugin. Now searches can find discussion titles, duplicate topics will not be returned, and the QnA plugin is no longer required. The code also has been cleaned up a bit and should run just a tad faster.
(It also appears that Brackets, the IDE I use, changed some of the formatting...)

This should fix #11 while also making the plugin a little easier to use.